### PR TITLE
Auth API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "slim/php-view": "^2.0",
         "monolog/monolog": "^1.17",
         "illuminate/database": ">=5.2.21",
-        "respect/validation": "^1.0"
+        "respect/validation": "^1.0",
+        "lcobucci/jwt": "^3.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "slim/slim": "^3.1",
         "slim/php-view": "^2.0",
         "monolog/monolog": "^1.17",
-        "illuminate/database": ">=5.2.21"
+        "illuminate/database": ">=5.2.21",
+        "respect/validation": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b5b71b915bfb924cd3cc544e51fb412d",
-    "content-hash": "246ed23269dbb895efb636e6cf954989",
+    "hash": "736970abd799c4cd959653cdb9d6eaaa",
+    "content-hash": "793d523260866b64109e6005cb7c7872",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -301,6 +301,64 @@
             "description": "The Illuminate Support package.",
             "homepage": "http://laravel.com",
             "time": "2016-02-22 20:29:02"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "31499db4e692b343cec7ff345932899f98fde1cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/31499db4e692b343cec7ff345932899f98fde1cf",
+                "reference": "31499db4e692b343cec7ff345932899f98fde1cf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "mdanter/ecc": "~0.3",
+                "mikey179/vfsstream": "~1.5",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/php-invoker": "~1.1",
+                "phpunit/phpunit": "~4.5",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "suggest": {
+                "mdanter/ecc": "Required to use Elliptic Curves based algorithms."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Otávio Cobucci Oblonczyk",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "time": "2015-11-15 01:42:47"
         },
         {
             "name": "monolog/monolog",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1d088a90989caca57d208c902fde1045",
-    "content-hash": "65e40ce4b5034ef070c690fc3070d265",
+    "hash": "b5b71b915bfb924cd3cc544e51fb412d",
+    "content-hash": "246ed23269dbb895efb636e6cf954989",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -602,6 +602,70 @@
                 "psr-3"
             ],
             "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "respect/validation",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Respect/Validation.git",
+                "reference": "4b2f15920627b93a0a4302e1e6e7db1bab1946e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Respect/Validation/zipball/4b2f15920627b93a0a4302e1e6e7db1bab1946e2",
+                "reference": "4b2f15920627b93a0a4302e1e6e7db1bab1946e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "~1.2",
+                "malkusch/bav": "~1.0",
+                "mikey179/vfsstream": "^1.5",
+                "phpunit/phpunit": "~4.0",
+                "symfony/validator": "~2.6.9",
+                "zendframework/zend-validator": "~2.3"
+            },
+            "suggest": {
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "ext-bcmath": "Arbitrary Precision Mathematics",
+                "ext-mbstring": "Multibyte String Functions",
+                "fabpot/php-cs-fixer": "Fix PSR2 and other coding style issues",
+                "malkusch/bav": "German bank account validation",
+                "symfony/validator": "Use Symfony validator through Respect\\Validation",
+                "zendframework/zend-validator": "Use Zend Framework validator through Respect\\Validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Respect\\Validation\\": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD Style"
+            ],
+            "authors": [
+                {
+                    "name": "Respect/Validation Contributors",
+                    "homepage": "https://github.com/Respect/Validation/graphs/contributors"
+                }
+            ],
+            "description": "The most awesome validation engine ever created for PHP",
+            "homepage": "http://respect.li",
+            "keywords": [
+                "respect",
+                "validation",
+                "validator"
+            ],
+            "time": "2016-02-26 15:21:26"
         },
         {
             "name": "slim/php-view",

--- a/data/pond.sql
+++ b/data/pond.sql
@@ -7,7 +7,7 @@
 #
 # Host: 127.0.0.1 (MySQL 5.5.47-0ubuntu0.14.04.1)
 # Database: pond
-# Generation Time: 2016-03-22 00:55:34 +0000
+# Generation Time: 2016-03-24 00:19:05 +0000
 # ************************************************************
 
 
@@ -19,7 +19,6 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
-USE DATABASE `pond`
 
 # Dump of table lesson_progress
 # ------------------------------------------------------------
@@ -85,6 +84,8 @@ CREATE TABLE `users` (
   `salt` char(64) DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
+  `validation_token` varchar(64) DEFAULT NULL,
+  `validated` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,3 +3,5 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]
+
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1

--- a/src/lib/Auth.php
+++ b/src/lib/Auth.php
@@ -7,16 +7,30 @@ use Slim\Http\Response;
 
 use Respect\Validation\Exceptions\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use \RuntimeException;
+
+use Slim\Container;
 
 use Lcobucci\JWT\Token;
-use Lcobucci\JWT\Signer\Hmac\Sha512 as Signer;
+use Lcobucci\JWT\Signer\Hmac\Sha256 as Signer;
+use Lcobucci\JWT\ValidationData;
+use Lcobucci\JWT\Parser;
+
 
 class Auth {
 
-    static public function loginHandler(Request $req, Response $res): Response {
+    private $container;
+    private $logger;
+
+    function __construct(Container $c) {
+        $this->container = $c;
+        $this->logger = $this->container->get('logger');
+    }
+
+    public function loginHandler(Request $req, Response $res): Response {
         $form = $req->getParsedBody();
 
-        if(! $token = self::authenticate($form['username'],$form['password']) ) {
+        if(! $token = self::authenticate(@$form['username'],@$form['password']) ) {
             return self::badAuthResponse($res);
         } else {
             return self::tokenResponse($res,$token);
@@ -24,44 +38,118 @@ class Auth {
 
     } // loginHandler
 
-    private static function authenticate($user, $password) {
+    public function isRequestAuthorized(Request $req, $forUID = null): bool {
+        // First, check for Authorization: Bearer [token]
+        // header
+
+        if(!$req->hasHeader('Authorization')) {
+            return false;
+        }
+
+        $tokenHeader = $req->getHeader('Authorization')[0]; // Bearer xxxxx.yyyyy.zzzzz
+        $tokenString = explode(' ', $tokenHeader)[1]; // xxxxx.yyyyy.zzzzz
+
+        try {
+            $parser = new Parser();
+            $token = $parser->parse($tokenString);
+        } catch(RuntimeException $e) {
+            // Token parsing failed, bad token assumed.
+            return false;
+        }
+
+        // Step 1: Validate the assertions in the JWT
+
+        $tokenSettings = $this->container->get('settings')['token'];
+
+        $issuer   = $tokenSettings['iss'];
+        $audience = $tokenSettings['aud'];
+        $lifetime = $tokenSettings['lifetime'];
+
+        $data = new ValidationData();
+        $data->setIssuer($issuer);
+        $data->setAudience($audience);
+
+        // If this token is being tested for user-specific auth
+        if(isset($forUID)) {
+            if( !($claimUID = $token->getClaim('uid')) ) {
+                return false;
+            } else {
+                if($forUID != $claimUID) {
+                    return false;
+                }
+            }
+        }
+
+        // Compare the Token with ValidationData
+        if(!$token->validate($data)) {
+            $this->logger->info("Invalid token claims.");
+            return false;
+        }
+
+        // Step 2. Verify signature
+        // [NOTA BENE] don't let JWT assert algorithm.
+        // Use predetermined algorithm and key for verification.
+        $signer = new Signer();
+        $signKey  = $tokenSettings['key'];
+        if($token->verify($signer, $signKey)) {
+            return true;
+        } else {
+            $this->logger->info("Could not verify token signature.");
+            return false;
+        }
+    }
+
+    private function authenticate($username, $password) {
         // Username format validation
         try {
-            \Pond\Validate::get('username')->check( $form['username'] ?? null );
+            \Pond\Validate::get('username')->check( $username );
         } catch(ValidationException $e) {
+            $this->logger->info('Username validation fail');
             return null;
         }
 
         // Password format validation
         try {
-            \Pond\Validate::get('password')->check( $form['password'] ?? null );
+            \Pond\Validate::get('password')->check( $password );
         } catch(ValidationException $e) {
+            $this->logger->info('Password validation fail');
             return null;
         }
 
         // Try to get the requested User or throw an exception
         try {
-            $reqUser = User::where('username', $form['username'])->firstOrFail();
+            $reqUser = User::where('username', $username)->firstOrFail();
         } catch(ModelNotFoundException $e) {
+            $this->logger->info('User model retrieval fail');
             return null;
         }
 
         // Check the password
         $knownP = $reqUser->password;
-        $givenP = new Crypto($form['password'], $reqUser->salt);
+        $givenP = new Crypto($password, $reqUser->salt);
 
         if(!Crypto::compare($knownP,$givenP)) {
+            $this->logger->info('Crypto authentication fail');
             return null;
         } else {
-            $tokenBuilder = new Lcobucci\JWT\Builder();
+            $tokenBuilder = new \Lcobucci\JWT\Builder();
             $signer = new Signer();
-            $token = $tokenBuilder->setIssuer('http://pondedu.me')
-                                 ->setAudience('http://pondedu.me')
+
+            $tokenSettings = $this->container->get('settings')['token'];
+            $signKey  = $tokenSettings['key'];
+
+            $issuer   = $tokenSettings['iss'];
+            $audience = $tokenSettings['aud'];
+            $lifetime = $tokenSettings['lifetime'];
+
+            $token = $tokenBuilder->setIssuer($issuer)
+                                 ->setAudience($audience)
                                  ->setIssuedAt(time())
-                                 ->setExpiration(time()+ 1 * 7 * 24 * 60 * 60) // 1 week
+                                 ->setExpiration(time() + $lifetime)
                                  ->set('uid', $reqUser->getKey())
-                                 ->sign($signer, $settings['token']['key'])
+                                 ->sign($signer, $signKey)
                                  ->getToken();
+            $this->logger->info('Building token');
             return $token;
         }
     }

--- a/src/lib/Auth.php
+++ b/src/lib/Auth.php
@@ -16,7 +16,6 @@ class Auth {
             return self::badAuthResponse($res);
         }
 
-
         return $res;
     } // loginHandler
 

--- a/src/lib/Auth.php
+++ b/src/lib/Auth.php
@@ -12,30 +12,44 @@ class Auth {
     static public function loginHandler(Request $req, Response $res): Response {
         $form = $req->getParsedBody();
 
+        if(! $token = self::authenticate($form['username'],$form['password']) ) {
+            return self::badAuthResponse($res);
+        }
+
+
+        return $res;
+    } // loginHandler
+
+    private static function authenticate($user, $password) {
         // Username format validation
         try {
             \Pond\Validate::get('username')->check( $form['username'] ?? null );
         } catch(ValidationException $e) {
-            return badAuthResponse($res);
+            return null;
         }
 
         // Password format validation
         try {
             \Pond\Validate::get('password')->check( $form['password'] ?? null );
         } catch(ValidationException $e) {
-            return badAuthResponse($res);
+            return null;
         }
 
         // Try to get the requested User or throw an exception
         try {
             $reqUser = User::where('username', $form['username'])->firstOrFail();
         } catch(ModelNotFoundException $e) {
-            return badAuthResponse($res);
+            return null;
         }
 
         // Check the password
-        return $res;
-    } // loginHandler
+        $knownP = $reqUser->password;
+        $givenP = new Crypto($form['password'], $reqUser->salt);
+
+        if(!Crypto::compare($knownP,$givenP)) {
+            return null;
+        }
+    }
 
     static function badAuthResponse(Response $res): Response {
         $stat = new \Pond\StatusContainer();
@@ -43,6 +57,15 @@ class Auth {
         $stat->message('Check your username and password.');
 
         $res = $res->withStatus(401); // Unauthorized
+        return $res->withJson($stat);
+    }
+
+    static function tokenResponse(Response $res, Token $t): Response {
+        $stat = new \Pond\StatusContainer( ['token' => (string)$t] );
+        $stat->success();
+        $stat->message('Successfully logged in.');
+
+        $res = $res->withStatus(201); // Created
         return $res->withJson($stat);
     }
 

--- a/src/lib/Auth.php
+++ b/src/lib/Auth.php
@@ -9,45 +9,41 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class Auth {
 
-    static public function loginHandler(Request $req, Response $res) {
+    static public function loginHandler(Request $req, Response $res): Response {
         $form = $req->getParsedBody();
 
         // Username format validation
         try {
-            \Pond\Validate::get('username')->check( $form['username'] );
+            \Pond\Validate::get('username')->check( $form['username'] ?? null );
         } catch(ValidationException $e) {
-            $stat = new \Pond\StatusContainer();
-            $stat->error('InvalidUsername');
-            $stat->message('Please enter a valid username.');
-
-            $res = $res->withStatus(400);
-            return $res->withJson($stat);
+            return badAuthResponse($res);
         }
 
         // Password format validation
         try {
-            \Pond\Validate::get('password')->check( $form['password'] );
+            \Pond\Validate::get('password')->check( $form['password'] ?? null );
         } catch(ValidationException $e) {
-            $stat = new \Pond\StatusContainer();
-            $stat->error('InvalidPassword');
-            $stat->message('Please enter a valid password.');
-
-            $res = $res->withStatus(400); // Bad Request
-            return $res->withJson($stat);
+            return badAuthResponse($res);
         }
 
         // Try to get the requested User or throw an exception
         try {
             $reqUser = User::where('username', $form['username'])->firstOrFail();
         } catch(ModelNotFoundException $e) {
-            $stat = new \Pond\StatusContainer();
-            $stat->error('BadAuth');
-            $stat->message('Check your username and password.');
-
-            $res = $res->withStatus(401); // Unauthorized
-            return $res->withJson($stat);
+            return badAuthResponse($res);
         }
+
+        // Check the password
         return $res;
     } // loginHandler
+
+    static function badAuthResponse(Response $res): Response {
+        $stat = new \Pond\StatusContainer();
+        $stat->error('BadAuth');
+        $stat->message('Check your username and password.');
+
+        $res = $res->withStatus(401); // Unauthorized
+        return $res->withJson($stat);
+    }
 
 } // Auth

--- a/src/lib/Auth.php
+++ b/src/lib/Auth.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Pond;
+
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Respect\Validation\Exceptions\ValidationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class Auth {
+
+    static public function loginHandler(Request $req, Response $res) {
+        $form = $req->getParsedBody();
+
+        // Username format validation
+        try {
+            \Pond\Validate::get('username')->check( $form['username'] );
+        } catch(ValidationException $e) {
+            $stat = new \Pond\StatusContainer();
+            $stat->error('InvalidUsername');
+            $stat->message('Please enter a valid username.');
+
+            $res = $res->withStatus(400);
+            return $res->withJson($stat);
+        }
+
+        // Password format validation
+        try {
+            \Pond\Validate::get('password')->check( $form['password'] );
+        } catch(ValidationException $e) {
+            $stat = new \Pond\StatusContainer();
+            $stat->error('InvalidPassword');
+            $stat->message('Please enter a valid password.');
+
+            $res = $res->withStatus(400); // Bad Request
+            return $res->withJson($stat);
+        }
+
+        // Try to get the requested User or throw an exception
+        try {
+            $reqUser = User::where('username', $form['username'])->firstOrFail();
+        } catch(ModelNotFoundException $e) {
+            $stat = new \Pond\StatusContainer();
+            $stat->error('BadAuth');
+            $stat->message('Check your username and password.');
+
+            $res = $res->withStatus(401); // Unauthorized
+            return $res->withJson($stat);
+        }
+        return $res;
+    } // loginHandler
+
+} // Auth

--- a/src/lib/Crypto.php
+++ b/src/lib/Crypto.php
@@ -13,7 +13,7 @@ class Crypto
     private $hash;
 
     // Generate a salt and store the hash
-    public function __construct(string $plain, $salt = false, $compute = true)
+    public function __construct($plain = false, $salt = false, $compute = true)
     {
         if (!$salt && $compute) {
             $this->salt = $this->generateSalt();

--- a/src/lib/User.php
+++ b/src/lib/User.php
@@ -3,5 +3,9 @@
 
     class User extends \Illuminate\Database\Eloquent\Model {
         public $primaryKey = 'user_id';
+
+        public function getPasswordAttribute($value) {
+            return Crypto::withHash($value, $this->salt);
+        }
     }
 ?>

--- a/src/lib/Validate.php
+++ b/src/lib/Validate.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Pond;
+
+use Respect\Validation\Validator as v;
+
+class Validate {
+
+    public static function get(string $name) {
+        switch ($name) {
+            case 'username':
+                return v::notEmpty()->alnum()->noWhitespace()->length(1,64);
+                break;
+
+            case 'password':
+                return v::notEmpty()->noWhitespace()->length(8,128);
+                break;
+
+            default:
+                throw new Exception("Validator `$name` does not exist", 1);
+                break;
+        }
+    }
+
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -10,5 +10,15 @@ $app->get('/', function ($request, $response, $args) {
 
 
 $app->post('/api/auth', function ($req, $res, $args) {
-    return \Pond\Auth::loginHandler($req, $res);
+    $auth = new \Pond\Auth($this);
+    return $auth->loginHandler($req, $res);
 });
+
+// Authorization example
+//
+// $app->get('/test/isauth/{user_id}', function($req, $res, $args) {
+//     $auth = new \Pond\Auth($this);
+//     $uid = $req->getAttribute('user_id');
+//     $isAuth = $auth->isRequestAuthorized($req,$uid);
+//     return $isAuth ? $res->withStatus(200) : $res->withStatus(401);
+// });

--- a/src/routes.php
+++ b/src/routes.php
@@ -10,6 +10,5 @@ $app->get('/', function ($request, $response, $args) {
 
 
 $app->post('/api/auth', function ($req, $res, $args) {
-    $this->logger->info("[Pond] POST /api/auth");
-    var_dump($args);
+    return \Pond\Auth::loginHandler($req, $res);
 });

--- a/src/routes.php
+++ b/src/routes.php
@@ -7,3 +7,9 @@ $app->get('/', function ($request, $response, $args) {
 
     return $this->renderer->render($response, 'index.phtml', $args);
 });
+
+
+$app->post('/api/auth', function ($req, $res, $args) {
+    $this->logger->info("[Pond] POST /api/auth");
+    var_dump($args);
+});

--- a/src/settings.php
+++ b/src/settings.php
@@ -26,5 +26,9 @@ return [
             'prefix' => '',
         ],
 
+        'token' => [
+            'key' => 'BethAq5d'
+        ]
+
     ],
 ];

--- a/src/settings.php
+++ b/src/settings.php
@@ -27,7 +27,10 @@ return [
         ],
 
         'token' => [
-            'key' => 'BethAq5d'
+            'key' => 'BethAq5d',
+            'iss' => 'http://pondedu.me',
+            'aud' => 'http://pondedu.me',
+            'lifetime' => 1 * 7 * 24 * 60 * 60, // 1 week
         ]
 
     ],


### PR DESCRIPTION
Significantly more detailed change logs in individual commit messages. The two components that are of interest to the rest of the team are:
- The addition of the `POST /api/auth` endpoint, which responds `200 OK` with a `StatusContainer` body wrapping a `token` value
- The addition of an `\Pond\Auth` class with a convenient `isRequestAuthorized(request, userID)`
